### PR TITLE
v1.2.0

### DIFF
--- a/build/azure-pipelines-release.yaml
+++ b/build/azure-pipelines-release.yaml
@@ -2,7 +2,7 @@ parameters:
 - name: VersionPrefix
   displayName: The version of the library
   type: string
-  default: 1.1.0
+  default: 1.2.0
 - name: VersionSuffix
   displayName: The version suffix of the library (rc.1). Use a space ' ' if no suffix.
   type: string

--- a/src/FluentAssertions.Json/FluentAssertions.Json.csproj
+++ b/src/FluentAssertions.Json/FluentAssertions.Json.csproj
@@ -13,6 +13,7 @@
     <PackageReleaseNotes>
       1.2.0
       - Add new override BeJsonSerializableInto() method to test polymorphism serialization with discriminator JSON property.
+      - Add the support to assert the deserialization of root JSON array.
 
       1.1.0
       - Allows to configure the JsonSerializationOptions globally and in specific assertions calls.

--- a/src/FluentAssertions.Json/FluentAssertions.Json.csproj
+++ b/src/FluentAssertions.Json/FluentAssertions.Json.csproj
@@ -11,9 +11,12 @@
     <PackageProjectUrl>https://github.com/PosInformatique/PosInformatique.FluentAssertions.Json</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+      1.2.0
+      - Add new override BeJsonSerializableInto() method to test polymorphism serialization with discriminator JSON property.
+
       1.1.0
       - Allows to configure the JsonSerializationOptions globally and in specific assertions calls.
-      
+
       1.0.5
       - Use the FluentAssertions library version 6.0.0 instead of 5.0.0 to fix breaking changes of the API.
 

--- a/src/FluentAssertions.Json/JsonElementComparer.cs
+++ b/src/FluentAssertions.Json/JsonElementComparer.cs
@@ -1,0 +1,195 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JsonElementComparer.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.FluentAssertions.Json
+{
+    using System.Collections;
+    using System.Reflection;
+    using System.Text.Json;
+
+    internal static class JsonElementComparer
+    {
+        public static IReadOnlyList<string> Compare(JsonDocument document, object? expected)
+        {
+            return Compare(document.RootElement, expected, "$");
+        }
+
+        public static IReadOnlyList<string> Compare(JsonElement element, object? expected, string initialPath)
+        {
+            var errors = new List<string>();
+
+            var path = new Stack<string>();
+
+            path.Push(initialPath);
+
+            Compare(element, expected, path, errors);
+
+            path.Pop();
+
+            return errors;
+        }
+
+        private static void Compare(JsonElement element, object? expected, Stack<string> path, List<string> errors)
+        {
+            if (element.ValueKind == JsonValueKind.String)
+            {
+                var value = element.GetString();
+
+                if (expected is not string expectedStringValue)
+                {
+                    errors.Add($"{GetPath(path)}: Expected property to be '{ReflectionHelper.GetJsonKind(expected)}' type instead of '{element.ValueKind}' type.");
+                    return;
+                }
+
+                if (value != expectedStringValue)
+                {
+                    errors.Add($"{GetPath(path)}: Expected '{expected}' instead of '{value}'.");
+                    return;
+                }
+            }
+            else if (element.ValueKind == JsonValueKind.Number)
+            {
+                var value = element.GetDouble();
+
+                if (expected == null || !ReflectionHelper.IsNumeric(expected))
+                {
+                    errors.Add($"{GetPath(path)}: Expected property to be '{ReflectionHelper.GetJsonKind(expected)}' type instead of '{element.ValueKind}' type.");
+                    return;
+                }
+
+                var expectedDoubleValue = Convert.ToDouble(expected);
+
+                if (value != expectedDoubleValue)
+                {
+                    errors.Add($"{GetPath(path)}: Expected '{expected}' instead of '{value}'.");
+                    return;
+                }
+            }
+            else if (element.ValueKind == JsonValueKind.Object)
+            {
+                if (expected is null || expected is string || ReflectionHelper.IsNumeric(expected) || expected is IEnumerable || expected is bool)
+                {
+                    errors.Add($"{GetPath(path)}: Expected property to be '{ReflectionHelper.GetJsonKind(expected)}' type instead of '{element.ValueKind}' type.");
+                    return;
+                }
+
+                var expectedPropertyEnumerator = expected.GetType().GetProperties().Cast<PropertyInfo>().GetEnumerator();
+
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (!expectedPropertyEnumerator.MoveNext())
+                    {
+                        errors.Add($"{GetPath(path)}: Expected no property but found '{property.Name}' property.");
+                        continue;
+                    }
+
+                    var expectedProperty = expectedPropertyEnumerator.Current;
+
+                    if (property.Name != expectedProperty.Name)
+                    {
+                        errors.Add($"{GetPath(path)}: Expected property with the '{expectedProperty.Name}' name but found '{property.Name}' instead.");
+                        continue;
+                    }
+
+                    path.Push("." + property.Name);
+
+                    var expectedValueOfProperty = expectedProperty.GetValue(expected);
+
+                    Compare(property.Value, expectedValueOfProperty, path, errors);
+
+                    path.Pop();
+                }
+
+                if (expectedPropertyEnumerator.MoveNext())
+                {
+                    errors.Add($"{GetPath(path)}: Expected '{expectedPropertyEnumerator.Current.Name}' property but found no property.");
+                    return;
+                }
+            }
+            else if (element.ValueKind == JsonValueKind.Array)
+            {
+                if (expected is string || expected is not IEnumerable expectedEnumerableValue)
+                {
+                    errors.Add($"{GetPath(path)}: Expected property to be '{ReflectionHelper.GetJsonKind(expected)}' type instead of '{element.ValueKind}' type.");
+                    return;
+                }
+
+                var expectedArrayEnumerator = expectedEnumerableValue.GetEnumerator();
+                var index = 0;
+
+                foreach (var item in element.EnumerateArray())
+                {
+                    if (!expectedArrayEnumerator.MoveNext())
+                    {
+                        var actualCount = element.EnumerateArray().Count();
+
+                        errors.Add($"{GetPath(path)}: Expected {index} item(s) but found {actualCount}.");
+                        continue;
+                    }
+
+                    var expectedItem = expectedArrayEnumerator.Current;
+
+                    path.Push($"[{index}]");
+
+                    Compare(item, expectedItem, path, errors);
+
+                    path.Pop();
+
+                    index++;
+                }
+
+                if (expectedArrayEnumerator.MoveNext())
+                {
+                    var expectedCount = ((IEnumerable)expected).Cast<object>().Count();
+
+                    errors.Add($"{GetPath(path)}: Expected {expectedCount} item(s) but found {index}.");
+                    return;
+                }
+            }
+            else if (element.ValueKind == JsonValueKind.True)
+            {
+                if (expected is not bool expectedBooleanValue)
+                {
+                    errors.Add($"{GetPath(path)}: Expected property to be '{ReflectionHelper.GetJsonKind(expected)}' type instead of '{element.ValueKind}' type.");
+                    return;
+                }
+
+                if (expectedBooleanValue != true)
+                {
+                    errors.Add($"{GetPath(path)}: Expected '{expected}' instead of '{true}'.");
+                    return;
+                }
+            }
+            else if (element.ValueKind == JsonValueKind.False)
+            {
+                if (expected is not bool expectedBooleanValue)
+                {
+                    errors.Add($"{GetPath(path)}: Expected property to be '{ReflectionHelper.GetJsonKind(expected)}' type instead of '{element.ValueKind}' type.");
+                    return;
+                }
+
+                if (expectedBooleanValue != false)
+                {
+                    errors.Add($"{GetPath(path)}: Expected '{expected}' instead of '{false}'.");
+                    return;
+                }
+            }
+            else
+            {
+                if (expected is not null)
+                {
+                    errors.Add($"{GetPath(path)}: Expected property to be '{ReflectionHelper.GetJsonKind(expected)}' type instead of '{element.ValueKind}' type.");
+                    return;
+                }
+            }
+        }
+
+        private static string GetPath(IEnumerable<string> path)
+        {
+            return string.Concat(path.Reverse());
+        }
+    }
+}

--- a/src/FluentAssertions.Json/JsonFluentAssertionsExtensions.cs
+++ b/src/FluentAssertions.Json/JsonFluentAssertionsExtensions.cs
@@ -150,9 +150,14 @@ namespace FluentAssertions
             BeJsonDeserializableIntoCore(assertions.Subject, expectedObject, optionsCopy);
         }
 
-        private static void BeJsonSerializableIntoCore<T>(ObjectAssertions assertions, object? expectedJson, JsonSerializerOptions options)
+        private static void BeJsonSerializableIntoCore<TBase>(ObjectAssertions assertions, object? expectedJson, JsonSerializerOptions options)
         {
-            var jsonString = JsonSerializer.Serialize((T)assertions.Subject, options);
+            if (assertions.Subject is not null && assertions.Subject is not TBase)
+            {
+                throw new ArgumentException($"The '{typeof(TBase).FullName}' class is not a base class of the '{assertions.Subject.GetType().FullName}' type.", nameof(TBase));
+            }
+
+            var jsonString = JsonSerializer.Serialize((TBase)assertions.Subject!, options);
 
             var deserializedJsonDocument = JsonSerializer.Deserialize<JsonDocument>(jsonString, options);
 

--- a/src/FluentAssertions.Json/JsonFluentAssertionsExtensions.cs
+++ b/src/FluentAssertions.Json/JsonFluentAssertionsExtensions.cs
@@ -190,6 +190,10 @@ namespace FluentAssertions
             {
                 opt.Using<object>(ctx =>
                 {
+                    // Test if the Subject is not a JsonElement.
+                    // This scenerio happen when deserializing JSON content in .NET object
+                    // which contains "object" property. In this case, the JsonSerializer will put JsonElement in this property.
+                    // So we have to compare the JsonElement with the expected .NET object specified by the developer in the unit tests.
                     if (ctx.Subject is JsonElement element)
                     {
                         var path = ReflectionHelper.GetJsonPath(deserializedObject!.GetType(), ctx.SelectedNode.PathAndName);

--- a/src/FluentAssertions.Json/JsonFluentAssertionsExtensions.cs
+++ b/src/FluentAssertions.Json/JsonFluentAssertionsExtensions.cs
@@ -30,7 +30,23 @@ namespace FluentAssertions
         /// will be used.</param>
         public static void BeJsonSerializableInto(this ObjectAssertions assertions, object? expectedJson, JsonSerializerOptions? options = null)
         {
-            BeJsonSerializableIntoCore(assertions, expectedJson, GetSerializerOptions(options));
+            BeJsonSerializableIntoCore<object>(assertions, expectedJson, GetSerializerOptions(options));
+        }
+
+        /// <summary>
+        /// Check if the subject object in <paramref name="assertions"/> instance is serializable into the JSON object
+        /// specified by the <paramref name="expectedJson"/>.
+        /// </summary>
+        /// <typeparam name="TBase">Base class type of the subject to use for the serialization. Defines explicitely the base type
+        /// to assert the JSON serialization with base class using polymorphisme discriminator.</typeparam>
+        /// <param name="assertions"><see cref="ObjectAssertions"/> which contains the object subject to check.</param>
+        /// <param name="expectedJson">The object which represents the raw JSON object expected.</param>
+        /// <param name="options"><see cref="JsonSerializerOptions"/> to use to assert the serialization. If not specified
+        /// the default <see cref="IFluentAssertionsJsonConfiguration.JsonSerializerOptions"/> of the <see cref="FluentAssertionsJson.Configuration"/>
+        /// will be used.</param>
+        public static void BeJsonSerializableInto<TBase>(this ObjectAssertions assertions, object? expectedJson, JsonSerializerOptions? options = null)
+        {
+            BeJsonSerializableIntoCore<TBase>(assertions, expectedJson, GetSerializerOptions(options));
         }
 
         /// <summary>
@@ -47,7 +63,26 @@ namespace FluentAssertions
 
             configureOptions(optionsCopy);
 
-            BeJsonSerializableIntoCore(assertions, expectedJson, optionsCopy);
+            BeJsonSerializableIntoCore<object>(assertions, expectedJson, optionsCopy);
+        }
+
+        /// <summary>
+        /// Check if the subject object in <paramref name="assertions"/> instance is serializable into the JSON object
+        /// specified by the <paramref name="expectedJson"/>.
+        /// </summary>
+        /// <typeparam name="TBase">Base class type of the subject to use for the serialization. Defines explicitely the base type
+        /// to assert the JSON serialization with base class using polymorphisme discriminator.</typeparam>
+        /// <param name="assertions"><see cref="ObjectAssertions"/> which contains the object subject to check.</param>
+        /// <param name="expectedJson">The object which represents the raw JSON object expected.</param>
+        /// <param name="configureOptions">Allows to change the default <see cref="IFluentAssertionsJsonConfiguration.JsonSerializerOptions"/>
+        /// of the <see cref="FluentAssertionsJson.Configuration"/> used to assert the serialization.</param>
+        public static void BeJsonSerializableInto<TBase>(this ObjectAssertions assertions, object? expectedJson, Action<JsonSerializerOptions> configureOptions)
+        {
+            var optionsCopy = new JsonSerializerOptions(FluentAssertionsJson.Configuration.JsonSerializerOptions);
+
+            configureOptions(optionsCopy);
+
+            BeJsonSerializableIntoCore<TBase>(assertions, expectedJson, optionsCopy);
         }
 
         /// <summary>
@@ -81,9 +116,9 @@ namespace FluentAssertions
             BeJsonDeserializableIntoCore(assertions, expectedObject, optionsCopy);
         }
 
-        private static void BeJsonSerializableIntoCore(this ObjectAssertions assertions, object? expectedJson, JsonSerializerOptions options)
+        private static void BeJsonSerializableIntoCore<T>(this ObjectAssertions assertions, object? expectedJson, JsonSerializerOptions options)
         {
-            var jsonString = JsonSerializer.Serialize(assertions.Subject, options);
+            var jsonString = JsonSerializer.Serialize((T)assertions.Subject, options);
 
             var deserializedJsonDocument = JsonSerializer.Deserialize<JsonDocument>(jsonString, options);
 

--- a/src/FluentAssertions.Json/JsonFluentAssertionsExtensions.cs
+++ b/src/FluentAssertions.Json/JsonFluentAssertionsExtensions.cs
@@ -9,6 +9,7 @@ namespace FluentAssertions
     using System.Reflection;
     using System.Text.Json;
     using System.Text.Json.Serialization;
+    using FluentAssertions.Collections;
     using FluentAssertions.Common;
     using FluentAssertions.Equivalency;
     using FluentAssertions.Primitives;
@@ -96,7 +97,22 @@ namespace FluentAssertions
         /// will be used.</param>
         public static void BeJsonDeserializableInto<T>(this ObjectAssertions assertions, T expectedObject, JsonSerializerOptions? options = null)
         {
-            BeJsonDeserializableIntoCore(assertions, expectedObject, GetSerializerOptions(options));
+            BeJsonDeserializableIntoCore(assertions.Subject, expectedObject, GetSerializerOptions(options));
+        }
+
+        /// <summary>
+        /// Check if the JSON subject collection is deserializable into the specified <paramref name="expectedObject"/> argument.
+        /// </summary>
+        /// <typeparam name="TElement">Type of the element of the collection to check the JSON deserialization.</typeparam>
+        /// <typeparam name="T">Type of the object to deserialize from JSON.</typeparam>
+        /// <param name="assertions"><see cref="ObjectAssertions"/> which contains the JSON collection subject to deserialize.</param>
+        /// <param name="expectedObject">Expected collection deserialized expected.</param>
+        /// <param name="options"><see cref="JsonSerializerOptions"/> to use to assert the deserialization. If not specified
+        /// the default <see cref="IFluentAssertionsJsonConfiguration.JsonSerializerOptions"/> of the <see cref="FluentAssertionsJson.Configuration"/>
+        /// will be used.</param>
+        public static void BeJsonDeserializableInto<TElement, T>(this GenericCollectionAssertions<TElement> assertions, T expectedObject, JsonSerializerOptions? options = null)
+        {
+            BeJsonDeserializableIntoCore(assertions.Subject, expectedObject, GetSerializerOptions(options));
         }
 
         /// <summary>
@@ -113,10 +129,28 @@ namespace FluentAssertions
 
             configureOptions(optionsCopy);
 
-            BeJsonDeserializableIntoCore(assertions, expectedObject, optionsCopy);
+            BeJsonDeserializableIntoCore(assertions.Subject, expectedObject, optionsCopy);
         }
 
-        private static void BeJsonSerializableIntoCore<T>(this ObjectAssertions assertions, object? expectedJson, JsonSerializerOptions options)
+        /// <summary>
+        /// Check if the JSON subject collection is deserializable into the specified <paramref name="expectedObject"/> argument.
+        /// </summary>
+        /// <typeparam name="TElement">Type of the element of the collection to check the JSON deserialization.</typeparam>
+        /// <typeparam name="T">Type of the object to deserialize from JSON.</typeparam>
+        /// <param name="assertions"><see cref="ObjectAssertions"/> which contains the JSON collection subject to deserialize.</param>
+        /// <param name="expectedObject">Expected collection deserialized expected.</param>
+        /// <param name="configureOptions">Allows to change the default <see cref="IFluentAssertionsJsonConfiguration.JsonSerializerOptions"/>
+        /// of the <see cref="FluentAssertionsJson.Configuration"/> used to assert the deserialization.</param>
+        public static void BeJsonDeserializableInto<TElement, T>(this GenericCollectionAssertions<TElement> assertions, T expectedObject, Action<JsonSerializerOptions> configureOptions)
+        {
+            var optionsCopy = new JsonSerializerOptions(FluentAssertionsJson.Configuration.JsonSerializerOptions);
+
+            configureOptions(optionsCopy);
+
+            BeJsonDeserializableIntoCore(assertions.Subject, expectedObject, optionsCopy);
+        }
+
+        private static void BeJsonSerializableIntoCore<T>(ObjectAssertions assertions, object? expectedJson, JsonSerializerOptions options)
         {
             var jsonString = JsonSerializer.Serialize((T)assertions.Subject, options);
 
@@ -139,9 +173,9 @@ namespace FluentAssertions
             Compare(deserializedJsonDocument!, expectedJsonDocument);
         }
 
-        private static void BeJsonDeserializableIntoCore<T>(this ObjectAssertions assertions, T expectedObject, JsonSerializerOptions options)
+        private static void BeJsonDeserializableIntoCore<T>(object subject, T expectedObject, JsonSerializerOptions options)
         {
-            var jsonText = JsonSerializer.Serialize(assertions.Subject, options);
+            var jsonText = JsonSerializer.Serialize(subject, options);
             var deserializedObject = JsonSerializer.Deserialize<T>(jsonText, options);
 
             deserializedObject.Should().BeEquivalentTo(expectedObject, opt =>

--- a/src/FluentAssertions.Json/ReflectionHelper.cs
+++ b/src/FluentAssertions.Json/ReflectionHelper.cs
@@ -6,11 +6,15 @@
 
 namespace PosInformatique.FluentAssertions.Json
 {
+    using System.Collections;
     using System.Reflection;
+    using System.Text.Json;
     using System.Text.Json.Serialization;
 
     internal static class ReflectionHelper
     {
+        private static readonly Type[] NumericTypes = new[] { typeof(int), typeof(double) };
+
         public static string GetJsonPropertyName(PropertyInfo property)
         {
             var jsonPropertyName = property.GetCustomAttribute<JsonPropertyNameAttribute>();
@@ -39,6 +43,53 @@ namespace PosInformatique.FluentAssertions.Json
             }
 
             return $"$.{string.Join(".", result)}";
+        }
+
+        public static JsonValueKind GetJsonKind(object? value)
+        {
+            if (value is null)
+            {
+                return JsonValueKind.Null;
+            }
+
+            if (value is string)
+            {
+                return JsonValueKind.String;
+            }
+
+            if (IsNumeric(value))
+            {
+                return JsonValueKind.Number;
+            }
+
+            if (value is IEnumerable)
+            {
+                return JsonValueKind.Array;
+            }
+
+            if (value is bool booleanValue)
+            {
+                if (booleanValue)
+                {
+                    return JsonValueKind.True;
+                }
+
+                return JsonValueKind.False;
+            }
+
+            return JsonValueKind.Object;
+        }
+
+        public static bool IsNumeric(object value)
+        {
+            var type = value.GetType();
+
+            if (NumericTypes.Contains(type))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/FluentAssertions.Json/ReflectionHelper.cs
+++ b/src/FluentAssertions.Json/ReflectionHelper.cs
@@ -1,0 +1,44 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ReflectionHelper.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.FluentAssertions.Json
+{
+    using System.Reflection;
+    using System.Text.Json.Serialization;
+
+    internal static class ReflectionHelper
+    {
+        public static string GetJsonPropertyName(PropertyInfo property)
+        {
+            var jsonPropertyName = property.GetCustomAttribute<JsonPropertyNameAttribute>();
+
+            if (jsonPropertyName is not null)
+            {
+                return jsonPropertyName.Name;
+            }
+
+            return property.Name;
+        }
+
+        public static string GetJsonPath(Type type, string path)
+        {
+            var propertyNames = path.Split('.');
+
+            var result = new List<string>();
+
+            foreach (var propertyName in propertyNames)
+            {
+                var property = type.GetProperty(propertyName);
+
+                result.Add(GetJsonPropertyName(property));
+
+                type = property.PropertyType;
+            }
+
+            return $"$.{string.Join(".", result)}";
+        }
+    }
+}

--- a/stylecop.json
+++ b/stylecop.json
@@ -2,7 +2,8 @@
   "settings": {
     "documentationRules": {
       "companyName": "P.O.S Informatique",
-      "copyrightText": "Copyright (c) {companyName}. All rights reserved."
+      "copyrightText": "Copyright (c) {companyName}. All rights reserved.",
+      "documentInternalElements": false
     }
   }
 }

--- a/tests/FluentAssertions.Json.Tests/FluentAssertions.Json.Tests.csproj
+++ b/tests/FluentAssertions.Json.Tests/FluentAssertions.Json.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
 
     <!-- Disable the StyleCop 'XML comment analysis is disabled due to project configuration' warning. -->

--- a/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
+++ b/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
@@ -618,6 +618,30 @@ namespace FluentAssertions.Json.Tests
                 });
         }
 
+        [Fact]
+        public void BeJsonSerializableInto_WithPolymorphism_WithWrongInheritance()
+        {
+            var point = new ThreeDimensionalPoint()
+            {
+                X = 1,
+                Y = 2,
+                Z = 3,
+            };
+
+            var act = () =>
+            {
+                point.Should().BeJsonSerializableInto<string>(
+                    new
+                    {
+                        myType = "3d",
+                    });
+            };
+
+            act.Should().ThrowExactly<ArgumentException>()
+                .WithMessage("The 'System.String' class is not a base class of the 'FluentAssertions.Json.Tests.JsonFluentAssertionsExtensionsTest+ThreeDimensionalPoint' type. (Parameter 'TBase')")
+                .And.ParamName.Should().Be("TBase");
+        }
+
         [Theory]
         [InlineData(1234)]
         [InlineData("The string")]

--- a/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
+++ b/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
@@ -799,6 +799,89 @@ namespace FluentAssertions.Json.Tests
             }
         }
 
+        [Fact]
+        public void BeJsonDeserializableInto_WithAnonymousArray()
+        {
+            var json = new[]
+            {
+                new
+                {
+                    X = 1,
+                    Y = 2,
+                },
+                new
+                {
+                    X = 3,
+                    Y = 4,
+                },
+            };
+
+            json.Should().BeJsonDeserializableInto(
+                new[]
+                {
+                    new BasePoint() { X = 1, Y = 2 },
+                    new BasePoint() { X = 3, Y = 4 },
+                });
+        }
+
+        [Fact]
+        public void BeJsonDeserializableInto_WithAnonymousArray_WithOptions()
+        {
+            var json = new[]
+            {
+                new
+                {
+                    x = 1,
+                    y = 2,
+                },
+                new
+                {
+                    x = 3,
+                    y = 4,
+                },
+            };
+
+            json.Should().BeJsonDeserializableInto(
+                new[]
+                {
+                    new BasePoint() { X = 1, Y = 2 },
+                    new BasePoint() { X = 3, Y = 4 },
+                },
+                new JsonSerializerOptions()
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                });
+        }
+
+        [Fact]
+        public void BeJsonDeserializableInto_WithAnonymousArray_WithOptionsConfigure()
+        {
+            var json = new[]
+            {
+                new
+                {
+                    x = 1,
+                    y = 2,
+                },
+                new
+                {
+                    x = 3,
+                    y = 4,
+                },
+            };
+
+            json.Should().BeJsonDeserializableInto(
+                new[]
+                {
+                    new BasePoint() { X = 1, Y = 2 },
+                    new BasePoint() { X = 3, Y = 4 },
+                },
+                opt =>
+                {
+                    opt.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+                });
+        }
+
         private class JsonSerializableClass
         {
             [JsonPropertyName("string_property")]

--- a/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
+++ b/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
@@ -782,6 +782,7 @@ namespace FluentAssertions.Json.Tests
                     {
                         object_property = value,
                     },
+                    collection_of_inner = (string)null,
                 });
         }
 

--- a/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
+++ b/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
@@ -8,6 +8,7 @@ namespace FluentAssertions.Json.Tests
 {
     using System.Text.Json;
     using System.Text.Json.Serialization;
+    using Newtonsoft.Json.Serialization;
     using PosInformatique.FluentAssertions.Json;
     using Xunit.Sdk;
 
@@ -550,6 +551,74 @@ namespace FluentAssertions.Json.Tests
         }
 
         [Fact]
+        public void BeJsonSerializableInto_WithPolymorphism()
+        {
+            var point = new ThreeDimensionalPoint()
+            {
+                X = 1,
+                Y = 2,
+                Z = 3,
+            };
+
+            point.Should().BeJsonSerializableInto<BasePoint>(
+                new
+                {
+                    myType = "3d",
+                    X = 1,
+                    Y = 2,
+                    Z = 3,
+                });
+        }
+
+        [Fact]
+        public void BeJsonSerializableInto_WithPolymorphism_WithOptions()
+        {
+            var point = new ThreeDimensionalPoint()
+            {
+                X = 1,
+                Y = 2,
+                Z = 3,
+            };
+
+            point.Should().BeJsonSerializableInto<BasePoint>(
+                new
+                {
+                    myType = "3d",
+                    x = 1,
+                    y = 2,
+                    z = 3,
+                },
+                new JsonSerializerOptions()
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                });
+        }
+
+        [Fact]
+        public void BeJsonSerializableInto_WithPolymorphism_AndConfigureOptions()
+        {
+            var point = new ThreeDimensionalPoint()
+            {
+                X = 1,
+                Y = 2,
+                Z = 3,
+            };
+
+            point.Should().BeJsonSerializableInto<BasePoint>(
+                new
+                {
+                    myType = "3d",
+                    x = 1,
+                    y = 2,
+                    z = 3,
+                },
+                opt =>
+                {
+                    opt.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+                });
+        }
+
+        [Fact]
         public void BeJsonDeserializableInto()
         {
             var json = new
@@ -796,6 +865,23 @@ namespace FluentAssertions.Json.Tests
             {
                 throw new NotImplementedException();
             }
+        }
+
+        [JsonPolymorphic(TypeDiscriminatorPropertyName = "myType")]
+        [JsonDerivedType(typeof(ThreeDimensionalPoint), typeDiscriminator: "3d")]
+        private class BasePoint
+        {
+            [JsonPropertyOrder(1)]
+            public int X { get; set; }
+
+            [JsonPropertyOrder(2)]
+            public int Y { get; set; }
+        }
+
+        private class ThreeDimensionalPoint : BasePoint
+        {
+            [JsonPropertyOrder(3)]
+            public int Z { get; set; }
         }
     }
 }

--- a/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
+++ b/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
@@ -1063,6 +1063,17 @@ namespace FluentAssertions.Json.Tests
                 {
                     object_property = value,
                 },
+                collection_of_inner = new[]
+                {
+                    new
+                    {
+                        object_property = value,
+                    },
+                    new
+                    {
+                        object_property = value,
+                    },
+                },
             };
 
             json.Should().BeJsonDeserializableInto(new ClassWithObjectProperty()
@@ -1070,6 +1081,17 @@ namespace FluentAssertions.Json.Tests
                 Inner = new InnerClassWithObjectProperty()
                 {
                     ObjectProperty = expectedValue,
+                },
+                InnerCollection = new List<InnerClassWithObjectProperty>()
+                {
+                    new InnerClassWithObjectProperty()
+                    {
+                        ObjectProperty = expectedValue,
+                    },
+                    new InnerClassWithObjectProperty()
+                    {
+                        ObjectProperty = expectedValue,
+                    },
                 },
             });
         }
@@ -1271,6 +1293,9 @@ namespace FluentAssertions.Json.Tests
         {
             [JsonPropertyName("inner")]
             public InnerClassWithObjectProperty Inner { get; set; }
+
+            [JsonPropertyName("collection_of_inner")]
+            public List<InnerClassWithObjectProperty> InnerCollection { get; set; }
         }
 
         private class InnerClassWithObjectProperty

--- a/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
+++ b/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
@@ -148,7 +148,7 @@ namespace FluentAssertions.Json.Tests
             };
 
             act.Should().ThrowExactly<XunitException>()
-                .WithMessage($"$.boolean_property: Expected property to be '{expectedValueString}' type instead of '{actualValueString}' type.");
+                .WithMessage($"$.boolean_property: Expected '{expectedValueString}' instead of '{actualValueString}'.");
         }
 
         [Fact]
@@ -342,7 +342,7 @@ namespace FluentAssertions.Json.Tests
         }
 
         [Fact]
-        public void BeJsonSerializableInto_PropertyTypeDifferent()
+        public void BeJsonSerializableInto_PropertyTypeDifferent_String()
         {
             var json = new JsonSerializableClass()
             {
@@ -359,6 +359,126 @@ namespace FluentAssertions.Json.Tests
 
             act.Should().ThrowExactly<XunitException>()
                 .WithMessage("$.string_property: Expected property to be 'Object' type instead of 'String' type.");
+        }
+
+        [Theory]
+        [InlineData("Expected string", "String")]
+        [InlineData(null, "Null")]
+        public void BeJsonSerializableInto_PropertyTypeDifferent_Number(object expectedValue, string expectedTypeMessage)
+        {
+            var json = new JsonSerializableClass()
+            {
+                StringProperty = "String value",
+                Int32Property = 1234,
+            };
+
+            var act = () =>
+            {
+                json.Should().BeJsonSerializableInto(new
+                {
+                    string_property = "String value",
+                    int32_property = expectedValue,
+                });
+            };
+
+            act.Should().ThrowExactly<XunitException>()
+                .WithMessage($"$.int32_property: Expected property to be '{expectedTypeMessage}' type instead of 'Number' type.");
+        }
+
+        [Theory]
+        [InlineData(true, "True")]
+        [InlineData(false, "False")]
+        public void BeJsonSerializableInto_PropertyTypeDifferent_Boolean(bool value, string insteadOfMessageString)
+        {
+            var json = new JsonSerializableClass()
+            {
+                StringProperty = "String value",
+                Int32Property = 1234,
+                BooleanProperty = value,
+            };
+
+            var act = () =>
+            {
+                json.Should().BeJsonSerializableInto(new
+                {
+                    string_property = "String value",
+                    int32_property = 1234,
+                    boolean_property = new { },
+                });
+            };
+
+            act.Should().ThrowExactly<XunitException>()
+                .WithMessage($"$.boolean_property: Expected property to be 'Object' type instead of '{insteadOfMessageString}' type.");
+        }
+
+        [Theory]
+        [InlineData("String value", "String")]
+        [InlineData(12.34, "Number")]
+        [InlineData(1234, "Number")]
+        [InlineData(true, "True")]
+        [InlineData(false, "False")]
+        [InlineData(null, "Null")]
+        public void BeJsonSerializableInto_PropertyTypeDifferent_Object(object value, string expectedKindMessage)
+        {
+            var json = new JsonSerializableClass()
+            {
+                StringProperty = "String value",
+                Int32Property = 1234,
+                BooleanProperty = true,
+                NullProperty = null,
+                InnerObject = new JsonSerializableClassInnerObject(),
+            };
+
+            var act = () =>
+            {
+                json.Should().BeJsonSerializableInto(new
+                {
+                    string_property = "String value",
+                    int32_property = 1234,
+                    boolean_property = true,
+                    null_property = (int?)null,
+                    inner_object = value,
+                });
+            };
+
+            act.Should().ThrowExactly<XunitException>()
+                .WithMessage($"$.inner_object: Expected property to be '{expectedKindMessage}' type instead of 'Object' type.");
+        }
+
+        [Theory]
+        [InlineData("String value", "String")]
+        [InlineData(12.34, "Number")]
+        [InlineData(1234, "Number")]
+        [InlineData(true, "True")]
+        [InlineData(false, "False")]
+        [InlineData(null, "Null")]
+        public void BeJsonSerializableInto_PropertyTypeDifferent_Array(object value, string expectedKindMessage)
+        {
+            var json = new JsonSerializableClass()
+            {
+                StringProperty = "String value",
+                Int32Property = 1234,
+                BooleanProperty = true,
+                NullProperty = null,
+                InnerObject = new JsonSerializableClassInnerObject() { InnerStringProperty = "Inner string" },
+                CollectionInt32 = new List<int> { 1, 2 },
+            };
+
+            var act = () =>
+            {
+                json.Should().BeJsonSerializableInto(new
+                {
+                    string_property = "String value",
+                    int32_property = 1234,
+                    boolean_property = true,
+                    null_property = (int?)null,
+                    inner_object = new { inner_string_property = "Inner string" },
+                    collection_int = value,
+                });
+            };
+
+            act.Should().ThrowExactly<XunitException>()
+                .WithMessage($"$.collection_int: Expected property to be '{expectedKindMessage}' type instead of 'Array' type.");
         }
 
         [Fact]
@@ -1007,7 +1127,7 @@ namespace FluentAssertions.Json.Tests
             };
 
             act.Should().ThrowExactly<XunitException>()
-                .WithMessage($"$.inner.object_property: Expected 'Other type' instead of '{value}'.");
+                .WithMessage($"$.inner.object_property: Expected property to be 'String' type instead of 'Number' type.");
         }
 
         [Fact]
@@ -1059,7 +1179,7 @@ namespace FluentAssertions.Json.Tests
             };
 
             act.Should().ThrowExactly<XunitException>()
-                .WithMessage("$.inner.object_property: Expected '1234' instead of 'The actual string'.");
+                .WithMessage("$.inner.object_property: Expected property to be 'Number' type instead of 'String' type.");
         }
 
         private class JsonSerializableClass

--- a/tests/FluentAssertions.Json.Tests/ReflectionHelperTest.cs
+++ b/tests/FluentAssertions.Json.Tests/ReflectionHelperTest.cs
@@ -1,0 +1,45 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ReflectionHelperTest.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.FluentAssertions.Json.Tests.Tests
+{
+    using System.Text.Json.Serialization;
+    using global::FluentAssertions;
+
+    public class ReflectionHelperTest
+    {
+        [Fact]
+        public void GetJsonPropertyName()
+        {
+            ReflectionHelper.GetJsonPropertyName(typeof(ObjectWithProperties).GetProperty("Property1")).Should().Be("Property1");
+            ReflectionHelper.GetJsonPropertyName(typeof(ObjectWithProperties).GetProperty("Property2")).Should().Be("property_2");
+        }
+
+        [Fact]
+        public void GetJsonPath()
+        {
+            ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot.PropertyRoot.InnerObject.Property1").Should().Be("$.root.root.InnerObject.Property1");
+            ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot.PropertyRoot.InnerObject.Property2").Should().Be("$.root.root.InnerObject.property_2");
+            ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot").Should().Be("$.root");
+        }
+
+        private class RootObject
+        {
+            [JsonPropertyName("root")]
+            public RootObject PropertyRoot { get; set; }
+
+            public ObjectWithProperties InnerObject { get; set; }
+        }
+
+        private class ObjectWithProperties
+        {
+            public string Property1 { get; set; }
+
+            [JsonPropertyName("property_2")]
+            public string Property2 { get; set; }
+        }
+    }
+}

--- a/tests/FluentAssertions.Json.Tests/ReflectionHelperTest.cs
+++ b/tests/FluentAssertions.Json.Tests/ReflectionHelperTest.cs
@@ -6,6 +6,7 @@
 
 namespace PosInformatique.FluentAssertions.Json.Tests.Tests
 {
+    using System.Text.Json;
     using System.Text.Json.Serialization;
     using global::FluentAssertions;
 
@@ -24,6 +25,34 @@ namespace PosInformatique.FluentAssertions.Json.Tests.Tests
             ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot.PropertyRoot.InnerObject.Property1").Should().Be("$.root.root.InnerObject.Property1");
             ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot.PropertyRoot.InnerObject.Property2").Should().Be("$.root.root.InnerObject.property_2");
             ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot").Should().Be("$.root");
+        }
+
+        [Fact]
+        public void GetJsonKind()
+        {
+            ReflectionHelper.GetJsonKind("The string").Should().Be(JsonValueKind.String);
+
+            ReflectionHelper.GetJsonKind(1234).Should().Be(JsonValueKind.Number);
+            ReflectionHelper.GetJsonKind(12.34).Should().Be(JsonValueKind.Number);
+
+            ReflectionHelper.GetJsonKind(new[] { 1 }).Should().Be(JsonValueKind.Array);
+            ReflectionHelper.GetJsonKind(new List<int> { 1 }).Should().Be(JsonValueKind.Array);
+
+            ReflectionHelper.GetJsonKind(new { }).Should().Be(JsonValueKind.Object);
+
+            ReflectionHelper.GetJsonKind(true).Should().Be(JsonValueKind.True);
+            ReflectionHelper.GetJsonKind(false).Should().Be(JsonValueKind.False);
+        }
+
+        [Fact]
+        public void IsNumeric()
+        {
+            ReflectionHelper.IsNumeric(1234).Should().BeTrue();
+            ReflectionHelper.IsNumeric(12.34).Should().BeTrue();
+
+            ReflectionHelper.IsNumeric("Not numeric").Should().BeFalse();
+            ReflectionHelper.IsNumeric(new { }).Should().BeFalse();
+            ReflectionHelper.IsNumeric(new[] { 1 }).Should().BeFalse();
         }
 
         private class RootObject

--- a/tests/FluentAssertions.Json.Tests/ReflectionHelperTest.cs
+++ b/tests/FluentAssertions.Json.Tests/ReflectionHelperTest.cs
@@ -25,6 +25,9 @@ namespace PosInformatique.FluentAssertions.Json.Tests.Tests
             ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot.PropertyRoot.InnerObject.Property1").Should().Be("$.root.root.InnerObject.Property1");
             ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot.PropertyRoot.InnerObject.Property2").Should().Be("$.root.root.InnerObject.property_2");
             ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot").Should().Be("$.root");
+
+            ReflectionHelper.GetJsonPath(typeof(RootObject), "CollectionImplicitName[0].Property1").Should().Be("$.CollectionImplicitName[0].Property1");
+            ReflectionHelper.GetJsonPath(typeof(RootObject), "CollectionExplicitName[xxx].Property2").Should().Be("$.collection_explicit_name[xxx].property_2");
         }
 
         [Fact]
@@ -61,6 +64,11 @@ namespace PosInformatique.FluentAssertions.Json.Tests.Tests
             public RootObject PropertyRoot { get; set; }
 
             public ObjectWithProperties InnerObject { get; set; }
+
+            public List<ObjectWithProperties> CollectionImplicitName { get; set; }
+
+            [JsonPropertyName("collection_explicit_name")]
+            public List<ObjectWithProperties> CollectionExplicitName { get; set; }
         }
 
         private class ObjectWithProperties


### PR DESCRIPTION
- Add new override BeJsonSerializableInto() method to test polymorphism serialization with discriminator JSON property. (fixes #14).
- Add the support to assert the deserialization of root JSON array. (fixes #13).
- Add the support of the "object" property. (fixes #12).