### PR TITLE
v1.7.0

### DIFF
--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: The version of the library
         required: true
-        default: 1.6.0
+        default: 1.7.0
       VersionSuffix:
         type: string
         description: The version suffix of the library (for example rc.1)

--- a/src/FluentAssertions.Json/FluentAssertions.Json.csproj
+++ b/src/FluentAssertions.Json/FluentAssertions.Json.csproj
@@ -11,6 +11,12 @@
     <PackageProjectUrl>https://github.com/PosInformatique/PosInformatique.FluentAssertions.Json</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+      1.7.0
+      - Fix the BeJsonDeserializableInto() when using polymorphism with object declared properties.
+
+      1.6.0
+      - Improves the BeJsonSerializableInto() and BeJsonDeserializableInto() methods to use C# raw string literal.
+
       1.5.0
       - Add the support of FluentAssertions 8.0.0.
 

--- a/src/FluentAssertions.Json/JsonFluentAssertionsExtensions.cs
+++ b/src/FluentAssertions.Json/JsonFluentAssertionsExtensions.cs
@@ -410,25 +410,26 @@ namespace FluentAssertions
         {
             deserializedObject.Should().BeEquivalentTo(expectedObject, opt =>
             {
-                opt.Using<object>(ctx =>
-                {
-                    // Test if the Subject is not a JsonElement.
-                    // This scenerio happen when deserializing JSON content in .NET object
-                    // which contains "object" property. In this case, the JsonSerializer will put JsonElement in this property.
-                    // So we have to compare the JsonElement with the expected .NET object specified by the developer in the unit tests.
-                    if (ctx.Subject is JsonElement element)
+                opt.RespectingRuntimeTypes()
+                    .Using<object>(ctx =>
                     {
-                        var path = ReflectionHelper.GetJsonPath(deserializedObject!.GetType(), ctx.SelectedNode.PathAndName);
-
-                        var errors = JsonElementComparer.CompareWithObject(element, ctx.Expectation, path);
-
-                        if (errors.Any())
+                        // Test if the Subject is not a JsonElement.
+                        // This scenerio happen when deserializing JSON content in .NET object
+                        // which contains "object" property. In this case, the JsonSerializer will put JsonElement in this property.
+                        // So we have to compare the JsonElement with the expected .NET object specified by the developer in the unit tests.
+                        if (ctx.Subject is JsonElement element)
                         {
-                            throw new JsonAssertionFailedException(errors.First());
+                            var path = ReflectionHelper.GetJsonPath(deserializedObject!, ctx.SelectedNode.PathAndName);
+
+                            var errors = JsonElementComparer.CompareWithObject(element, ctx.Expectation, path);
+
+                            if (errors.Any())
+                            {
+                                throw new JsonAssertionFailedException(errors.First());
+                            }
                         }
-                    }
-                })
-                .When(member => member.Type == typeof(object));
+                    })
+                    .When(member => member.Type == typeof(object));
 
                 return opt.Excluding(member => IsIgnoredProperty(member));
             });

--- a/src/FluentAssertions.Json/ReflectionHelper.cs
+++ b/src/FluentAssertions.Json/ReflectionHelper.cs
@@ -8,7 +8,6 @@ namespace PosInformatique.FluentAssertions.Json
 {
     using System.Collections;
     using System.Reflection;
-    using System.Runtime.InteropServices;
     using System.Text.Json;
     using System.Text.Json.Serialization;
 
@@ -28,7 +27,7 @@ namespace PosInformatique.FluentAssertions.Json
             return property.Name;
         }
 
-        public static string GetJsonPath(Type type, string path)
+        public static string GetJsonPath(object instance, string path)
         {
             var propertyNames = path.Split('.');
 
@@ -46,7 +45,7 @@ namespace PosInformatique.FluentAssertions.Json
                     propertyName = p.Substring(0, indexArray);
                 }
 
-                var property = type.GetProperty(propertyName);
+                var property = instance.GetType().GetProperty(propertyName);
 
                 result.Add(GetJsonPropertyName(property));
 
@@ -57,11 +56,15 @@ namespace PosInformatique.FluentAssertions.Json
 
                     result[result.Count - 1] = result[result.Count - 1] + indexString;
 
-                    type = GetEnumerableElementType(property.PropertyType);
+                    instance = property.GetValue(instance, null);
+
+                    // Gets the item of the list
+                    indexString = indexString.TrimStart("[").TrimEnd("]").ToString();
+                    instance = GetListItem(instance, indexString);
                 }
                 else
                 {
-                    type = property.PropertyType;
+                    instance = property.GetValue(instance, null);
                 }
             }
 
@@ -115,12 +118,14 @@ namespace PosInformatique.FluentAssertions.Json
             return false;
         }
 
-        private static Type GetEnumerableElementType(Type collectionType)
+        private static object GetListItem(object collection, string indexString)
         {
-            var enumerableType = collectionType.GetInterface("IEnumerable`1");
-            var elementType = enumerableType.GetGenericArguments()[0];
+            var itemProperty = collection.GetType().GetProperty("Item");
 
-            return elementType;
+            var itemType = itemProperty.GetIndexParameters()[0].ParameterType;
+            var index = Convert.ChangeType(indexString, itemType);
+
+            return itemProperty.GetValue(collection, [index]);
         }
     }
 }

--- a/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
+++ b/tests/FluentAssertions.Json.Tests/JsonFluentAssertionsExtensionsTest.cs
@@ -676,6 +676,11 @@ namespace FluentAssertions.Json.Tests
                 X = 1,
                 Y = 2,
                 Z = 3,
+                Attributes = new Dictionary<string, object>
+                {
+                    { "Attribute1", "Value 1" },
+                    { "Attribute2", 2 },
+                },
             };
 
             point.Should().BeJsonSerializableInto<BasePoint>(
@@ -685,6 +690,11 @@ namespace FluentAssertions.Json.Tests
                     X = 1,
                     Y = 2,
                     Z = 3,
+                    Attributes = new
+                    {
+                        Attribute1 = "Value 1",
+                        Attribute2 = 2,
+                    },
                 });
         }
 
@@ -696,6 +706,11 @@ namespace FluentAssertions.Json.Tests
                 X = 1,
                 Y = 2,
                 Z = 3,
+                Attributes = new Dictionary<string, object>
+                {
+                    { "Attribute1", "Value 1" },
+                    { "Attribute2", 2 },
+                },
             };
 
             point.Should().BeJsonSerializableInto<BasePoint>(
@@ -705,6 +720,11 @@ namespace FluentAssertions.Json.Tests
                     x = 1,
                     y = 2,
                     z = 3,
+                    attributes = new
+                    {
+                        Attribute1 = "Value 1",
+                        Attribute2 = 2,
+                    },
                 },
                 new JsonSerializerOptions()
                 {
@@ -720,6 +740,11 @@ namespace FluentAssertions.Json.Tests
                 X = 1,
                 Y = 2,
                 Z = 3,
+                Attributes = new Dictionary<string, object>
+                {
+                    { "Attribute1", "Value 1" },
+                    { "Attribute2", 2 },
+                },
             };
 
             point.Should().BeJsonSerializableInto<BasePoint>(
@@ -729,6 +754,11 @@ namespace FluentAssertions.Json.Tests
                     x = 1,
                     y = 2,
                     z = 3,
+                    attributes = new
+                    {
+                        Attribute1 = "Value 1",
+                        Attribute2 = 2,
+                    },
                 },
                 opt =>
                 {
@@ -758,6 +788,42 @@ namespace FluentAssertions.Json.Tests
             act.Should().ThrowExactly<ArgumentException>()
                 .WithMessage("The 'System.String' class is not a base class of the 'FluentAssertions.Json.Tests.JsonFluentAssertionsExtensionsTest+ThreeDimensionalPoint' type. (Parameter 'TBase')")
                 .And.ParamName.Should().Be("TBase");
+        }
+
+        [Fact]
+        public void BeJsonSerializableInto_WithPolymorphism_ObjectProperty()
+        {
+            var point = new ClassWithPolymorphicObjectProperty()
+            {
+                Point = new ThreeDimensionalPoint()
+                {
+                    X = 1,
+                    Y = 2,
+                    Z = 3,
+                    Attributes = new Dictionary<string, object>
+                    {
+                        { "Attribute1", "Value 1" },
+                        { "Attribute2", 2 },
+                    },
+                },
+            };
+
+            point.Should().BeJsonSerializableInto(
+                new
+                {
+                    point = new
+                    {
+                        myType = "3d",
+                        X = 1,
+                        Y = 2,
+                        Z = 3,
+                        Attributes = new
+                        {
+                            Attribute1 = "Value 1",
+                            Attribute2 = 2,
+                        },
+                    },
+                });
         }
 
         [Theory]
@@ -1458,6 +1524,11 @@ namespace FluentAssertions.Json.Tests
                 X = 1,
                 Y = 2,
                 Z = 3,
+                Attributes = new Dictionary<string, object>
+                {
+                    { "Attribute 1", "Value 1" },
+                    { "Attribute 2", 2 },
+                },
             };
 
             point.Should().BeJsonSerializableInto<BasePoint>(
@@ -1466,7 +1537,12 @@ namespace FluentAssertions.Json.Tests
                     "myType": "3d",
                     "X": 1,
                     "Y": 2,
-                    "Z": 3
+                    "Z": 3,
+                    "Attributes":
+                    {
+                        "Attribute 1": "Value 1",
+                        "Attribute 2": 2
+                    }
                 }
                 """);
         }
@@ -1479,6 +1555,11 @@ namespace FluentAssertions.Json.Tests
                 X = 1,
                 Y = 2,
                 Z = 3,
+                Attributes = new Dictionary<string, object>
+                {
+                    { "Attribute 1", "Value 1" },
+                    { "Attribute 2", 2 },
+                },
             };
 
             point.Should().BeJsonSerializableInto<BasePoint>(
@@ -1487,7 +1568,12 @@ namespace FluentAssertions.Json.Tests
                     "myType": "3d",
                     "x": 1,
                     "y": 2,
-                    "z": 3
+                    "z": 3,
+                    "attributes":
+                    {
+                        "Attribute 1": "Value 1",
+                        "Attribute 2": 2
+                    }
                 }
                 """,
                 new JsonSerializerOptions()
@@ -1504,6 +1590,11 @@ namespace FluentAssertions.Json.Tests
                 X = 1,
                 Y = 2,
                 Z = 3,
+                Attributes = new Dictionary<string, object>
+                {
+                    { "Attribute 1", "Value 1" },
+                    { "Attribute 2", 2 },
+                },
             };
 
             point.Should().BeJsonSerializableInto<BasePoint>(
@@ -1512,7 +1603,12 @@ namespace FluentAssertions.Json.Tests
                     "myType": "3d",
                     "x": 1,
                     "y": 2,
-                    "z": 3
+                    "z": 3,
+                    "attributes":
+                    {
+                        "Attribute 1": "Value 1",
+                        "Attribute 2": 2
+                    }
                 }
                 """,
                 opt =>
@@ -2236,6 +2332,76 @@ namespace FluentAssertions.Json.Tests
                 });
         }
 
+        [Fact]
+        public void BeJsonDeserializableInto_WithPolymorphism()
+        {
+            var json =
+                """
+                {
+                    "myType": "3d",
+                    "X": 1,
+                    "Y": 2,
+                    "Z": 3,
+                    "Attributes":
+                    {
+                        "Attribute1": "Value 1",
+                        "Attribute2": 2
+                    }
+                }
+                """;
+
+            json.Should().BeJsonDeserializableInto(
+                new ThreeDimensionalPoint()
+                {
+                    X = 1,
+                    Y = 2,
+                    Z = 3,
+                    Attributes = new Dictionary<string, object>
+                    {
+                        { "Attribute1", "Value 1" },
+                        { "Attribute2", 2 },
+                    },
+                });
+        }
+
+        [Fact]
+        public void BeJsonDeserializableInto_WithPolymorphism_ObjectProperty()
+        {
+            var json =
+                """
+                {
+                    "point":
+                    {
+                        "myType": "3d",
+                        "X": 1,
+                        "Y": 2,
+                        "Z": 3,
+                        "Attributes":
+                        {
+                            "Attribute1": "Value 1",
+                            "Attribute2": 2
+                        }
+                    }
+                }
+                """;
+
+            json.Should().BeJsonDeserializableInto(
+                new ClassWithPolymorphicObjectProperty()
+                {
+                    Point = new ThreeDimensionalPoint()
+                    {
+                        X = 1,
+                        Y = 2,
+                        Z = 3,
+                        Attributes = new Dictionary<string, object>
+                        {
+                            { "Attribute1", "Value 1" },        // Should throw exception for this value...
+                            { "Attribute2", 2 },
+                        },
+                    },
+                });
+        }
+
         private class JsonSerializableClass
         {
             [JsonPropertyName("string_property")]
@@ -2319,6 +2485,15 @@ namespace FluentAssertions.Json.Tests
         {
             [JsonPropertyOrder(3)]
             public int Z { get; set; }
+
+            [JsonPropertyOrder(4)]
+            public Dictionary<string, object> Attributes { get; set; }
+        }
+
+        private class ClassWithPolymorphicObjectProperty
+        {
+            [JsonPropertyName("point")]
+            public BasePoint Point { get; set; }
         }
 
         private class ClassWithObjectProperty

--- a/tests/FluentAssertions.Json.Tests/ReflectionHelperTest.cs
+++ b/tests/FluentAssertions.Json.Tests/ReflectionHelperTest.cs
@@ -22,12 +22,41 @@ namespace PosInformatique.FluentAssertions.Json.Tests.Tests
         [Fact]
         public void GetJsonPath()
         {
-            ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot.PropertyRoot.InnerObject.Property1").Should().Be("$.root.root.InnerObject.Property1");
-            ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot.PropertyRoot.InnerObject.Property2").Should().Be("$.root.root.InnerObject.property_2");
-            ReflectionHelper.GetJsonPath(typeof(RootObject), "PropertyRoot").Should().Be("$.root");
+            var @object = new RootObject()
+            {
+                PropertyRoot = new RootObject()
+                {
+                    PropertyRoot = new RootObject()
+                    {
+                        InnerObject = new ObjectWithProperties(),
+                    },
+                },
+                InnerObject = new InheritedObjectWithProperties(),
+                CollectionExplicitName = new Dictionary<string, ObjectWithProperties>
+                {
+                    { "xxx", new ObjectWithProperties() },
+                    { "yyy", new ObjectWithProperties() },
+                },
+                CollectionImplicitName = new List<ObjectWithProperties>
+                {
+                    new ObjectWithProperties(),
+                    new ObjectWithProperties(),
+                },
+            };
 
-            ReflectionHelper.GetJsonPath(typeof(RootObject), "CollectionImplicitName[0].Property1").Should().Be("$.CollectionImplicitName[0].Property1");
-            ReflectionHelper.GetJsonPath(typeof(RootObject), "CollectionExplicitName[xxx].Property2").Should().Be("$.collection_explicit_name[xxx].property_2");
+            ReflectionHelper.GetJsonPath(@object, "PropertyRoot.PropertyRoot.InnerObject.Property1").Should().Be("$.root.root.InnerObject.Property1");
+            ReflectionHelper.GetJsonPath(@object, "PropertyRoot.PropertyRoot.InnerObject.Property2").Should().Be("$.root.root.InnerObject.property_2");
+            ReflectionHelper.GetJsonPath(@object, "PropertyRoot").Should().Be("$.root");
+
+            ReflectionHelper.GetJsonPath(@object, "InnerObject.Property1").Should().Be("$.InnerObject.Property1");
+            ReflectionHelper.GetJsonPath(@object, "InnerObject.Property2").Should().Be("$.InnerObject.property_2");
+            ReflectionHelper.GetJsonPath(@object, "InnerObject.Property3").Should().Be("$.InnerObject.Property3");
+            ReflectionHelper.GetJsonPath(@object, "InnerObject.Property4").Should().Be("$.InnerObject.property_4");
+
+            ReflectionHelper.GetJsonPath(@object, "CollectionImplicitName[0].Property1").Should().Be("$.CollectionImplicitName[0].Property1");
+            ReflectionHelper.GetJsonPath(@object, "CollectionImplicitName[1].Property1").Should().Be("$.CollectionImplicitName[1].Property1");
+            ReflectionHelper.GetJsonPath(@object, "CollectionExplicitName[xxx].Property2").Should().Be("$.collection_explicit_name[xxx].property_2");
+            ReflectionHelper.GetJsonPath(@object, "CollectionExplicitName[yyy].Property2").Should().Be("$.collection_explicit_name[yyy].property_2");
         }
 
         [Fact]
@@ -68,7 +97,7 @@ namespace PosInformatique.FluentAssertions.Json.Tests.Tests
             public List<ObjectWithProperties> CollectionImplicitName { get; set; }
 
             [JsonPropertyName("collection_explicit_name")]
-            public List<ObjectWithProperties> CollectionExplicitName { get; set; }
+            public Dictionary<string, ObjectWithProperties> CollectionExplicitName { get; set; }
         }
 
         private class ObjectWithProperties
@@ -77,6 +106,14 @@ namespace PosInformatique.FluentAssertions.Json.Tests.Tests
 
             [JsonPropertyName("property_2")]
             public string Property2 { get; set; }
+        }
+
+        private class InheritedObjectWithProperties : ObjectWithProperties
+        {
+            public string Property3 { get; set; }
+
+            [JsonPropertyName("property_4")]
+            public string Property4 { get; set; }
         }
     }
 }


### PR DESCRIPTION
- Use the [PreferringRuntimeMemberTypes()](https://fluentassertions.com/objectgraphs/#compile-time-types-vs-run-time-types) option when comparing Json deserialized objects to compare exactly the same object type when using polymorphism (fixes #23).